### PR TITLE
Update 1.rnn-lstm-crf.ipynb

### DIFF
--- a/entity-tagging/1.rnn-lstm-crf.ipynb
+++ b/entity-tagging/1.rnn-lstm-crf.ipynb
@@ -252,7 +252,7 @@
     "        self.char_ids = tf.placeholder(tf.int32, shape = [None, None, None])\n",
     "        self.labels = tf.placeholder(tf.int32, shape = [None, None])\n",
     "        self.maxlen = tf.shape(self.word_ids)[1]\n",
-    "        self.lengths = tf.count_nonzero(self.word_ids, 1)\n",
+    "        self.lengths = tf.count_nonzero(self.word_ids, 1, dtype = tf.int32)\n",
     "\n",
     "        self.word_embeddings = tf.Variable(\n",
     "            tf.truncated_normal(\n",


### PR DESCRIPTION
fix bug: TypeError: Input 'y' of 'Maximum' Op has type int64 that does not match type int32 of argument 'x'.